### PR TITLE
Use glide to aid granate users with getting deps

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,33 @@
+hash: db08871f89b3b4551fca5e75959d211d84d2ef7a926e7ca260882ab29f3fd126
+updated: 2017-08-11T13:21:53.807452441+02:00
+imports:
+- name: github.com/graphql-go/graphql
+  version: 105a6c24e6fdaf4008e56d947115a1a13dc46430
+  subpackages:
+  - gqlerrors
+  - language/ast
+  - language/kinds
+  - language/lexer
+  - language/location
+  - language/parser
+  - language/printer
+  - language/source
+  - language/typeInfo
+  - language/visitor
+- name: github.com/graphql-go/relay
+  version: 9054c3f9e4f31c403e404f1292d6d12874d1fdc5
+- name: github.com/jessevdk/go-flags
+  version: 96dc06278ce32a0e9d957d590bb987c81ee66407
+- name: github.com/mitchellh/mapstructure
+  version: d0303fe809921458f417bcf828397a65db30a7e4
+- name: golang.org/x/net
+  version: 1c05540f6879653db88113bc4a2b70aec4bd491f
+  subpackages:
+  - context
+- name: golang.org/x/tools
+  version: 5831d16d18029819d39f99bdc2060b8eff410b6b
+  subpackages:
+  - cmd/goimports
+- name: gopkg.in/yaml.v2
+  version: 25c4ec802a7d637f88d584ab26798e94ad14c13b
+testImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,20 @@
+package: github.com/granateio/granate
+import:
+- package: github.com/graphql-go/graphql
+  version: ^0.7.2
+  subpackages:
+  - language/ast
+  - language/kinds
+  - language/parser
+  - language/source
+- package: github.com/jessevdk/go-flags
+  version: ^1.3.0
+- package: golang.org/x/net
+  subpackages:
+  - context
+- package: gopkg.in/yaml.v2
+- package: golang.org/x/tools
+  subpackages:
+  - cmd/goimports
+- package: github.com/mitchellh/mapstructure
+- package: github.com/graphql-go/relay


### PR DESCRIPTION
ref #18.

Whether we need to require specific versions now can be debated, but it helps a lot to be able to use something like Glide to go get all dependencies.