### PR TITLE
Use stdlib context for lib

### DIFF
--- a/lib/lib.go
+++ b/lib/lib.go
@@ -2,9 +2,9 @@ package lib
 
 import (
 	"errors"
+	"context"
 
 	"github.com/graphql-go/graphql"
-	"golang.org/x/net/context"
 )
 
 type IDFieldInterface interface {


### PR DESCRIPTION
I noticed after `dep ensure` on my project that the old experimental `context` package was being saved because of the imports in `lib`. 1838e3c0bcbad5488a11d3fc738503675ace73e8 changed a lot of them, but didn't change this one. Was that intentional?